### PR TITLE
Fix: Properly delete directories when removing old backups

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -79,14 +79,19 @@ class Backup:
 
     def delete_oldest_files_in_dir_if_over_max(self):
         # Remove oldest backup so we don't store too many
-        list_of_backups = os.listdir(self.backup_path)         
+        list_of_backups = os.listdir(self.backup_path)
 
         if len(list_of_backups) > self.max_local_backups:
             for i in range(len(list_of_backups) - self.max_local_backups):
-                full_paths = [f"{os.path.join(self.backup_path, x)}" for x in os.listdir(self.backup_path)]                
+                full_paths = [f"{os.path.join(self.backup_path, x)}" for x in os.listdir(self.backup_path)]
                 oldest_file = min(full_paths, key=os.path.getctime)
-                os.remove(oldest_file)
-                cprint(f"&cRemoved {oldest_file} as it was the oldest backup")
+
+                if os.path.isdir(oldest_file):
+                    shutil.rmtree(oldest_file)
+                    cprint(f"&cRemoved {oldest_file} as it was the oldest backup directory")
+                else:
+                    os.remove(oldest_file)
+                    cprint(f"&cRemoved {oldest_file} as it was the oldest backup file")
 
     def zip_files(self):
         # ! IMPORTANT: Switch to https://pypi.org/project/aiozipstream/


### PR DESCRIPTION
This PR fixes an issue where the script would fail when trying to remove an old backup that was a directory. The `delete_oldest_files_in_dir_if_over_max()` function has been updated to properly handle both files and directories.